### PR TITLE
Add feature flags

### DIFF
--- a/feature_flags.json
+++ b/feature_flags.json
@@ -1,0 +1,3 @@
+{
+  "conferenceCalling": false
+}

--- a/feature_flags.json
+++ b/feature_flags.json
@@ -1,3 +1,3 @@
 {
-  "conferenceCalling": false
+    "conferenceCalling": false
 }


### PR DESCRIPTION
Build configurations must now contain a feature flags configuration file. Currently there is just one flag, `conferenceCalling`, which is disabled for this configuration.