### PR TITLE
[Feature]: Hide User Profile Camera Roll Configuration Flag

### DIFF
--- a/session_manager.json
+++ b/session_manager.json
@@ -6,5 +6,6 @@
     "forceAppLock": false,
     "appLockTimeout": 10,
     "authenticateAfterReboot": false,
-    "useBiometricsOrAccountPassword": false
+    "useBiometricsOrAccountPassword": false,
+    "showCameraRollOnUserProfile": false
 }

--- a/session_manager.json
+++ b/session_manager.json
@@ -7,5 +7,5 @@
     "appLockTimeout": 10,
     "authenticateAfterReboot": false,
     "useBiometricsOrAccountPassword": false,
-    "showCameraRollOnUserProfile": false
+    "showCameraRollOnUserProfile": true
 }


### PR DESCRIPTION
What's new in this PR?

from the session_manager configuration file it is now possible to show or hide the camera roll button in the user profile

Dependency

JIRA Ticket: https://wearezeta.atlassian.net/browse/ZIOS-13659