### PR TITLE
[Chore] Delete unused option

### DIFF
--- a/session_manager.json
+++ b/session_manager.json
@@ -3,7 +3,6 @@
     "blacklistDownloadInterval": 21600,
     "blockOnJailbreakOrRoot": false,
     "wipeOnJailbreakOrRoot": false,
-    "forceCustomAppLock": true,
     "forceAppLock": false,
     "appLockTimeout": 10,
     "authenticateAfterReboot": false,


### PR DESCRIPTION
I searched `wire-ios` and `wire-ios-sync-engine` and as far as I can tell this option is no longer exists.