### PR TITLE
[Refactor] Remove useCustomCodeInsteadOfAccountPassword

### DIFF
--- a/session_manager.json
+++ b/session_manager.json
@@ -6,7 +6,6 @@
     "forceAppLock": false,
     "appLockTimeout": 10,
     "authenticateAfterReboot": false,
-    "useBiometricsOrAccountPassword": false,
-    "useCustomCodeInsteadOfAccountPassword": false,
+    "useBiometricsOrCustomPasscode": false,
     "encryptionAtRestEnabledByDefault": false
 }


### PR DESCRIPTION
Remove useCustomCodeInsteadOfAccountPassword from the `session_manager.json`. 