### PR TITLE
xcode12: fix simulator build not compile for arm64 issue

### DIFF
--- a/Base.xcconfig
+++ b/Base.xcconfig
@@ -20,3 +20,5 @@
 
 WIRE_PRODUCT_NAME = Wire
 EXCLUDED_ARCHS = i386
+EXCLUDED_ARCHS[sdk=iphonesimulator14.4] = "i386 arm64";
+

--- a/Base.xcconfig
+++ b/Base.xcconfig
@@ -20,5 +20,4 @@
 
 WIRE_PRODUCT_NAME = Wire
 EXCLUDED_ARCHS = i386
-EXCLUDED_ARCHS[sdk=iphonesimulator14.4] = "i386 arm64";
-
+EXCLUDED_ARCHS[sdk=iphonesimulator*] = i386 arm64


### PR DESCRIPTION
Exclude arm64 for simulator build target to prevent build error on Xcode 12.4